### PR TITLE
Refactor Makefile, add recipe for .o file build

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,14 +1,42 @@
 FILES = main.c glad.c shader.c model_loader.c model.c entity.c obj_preprocessor.c material.c helpers.c animation.c oct_tree.c physics.c simulation.c init.c
+OBJ_FILES = shader.c model_loader.c model.c entity.c obj_preprocessor.c material.c helpers.c animation.c oct_tree.c physics.c simulation.c init.c
+FLAGS = -Wall -Werror
+FLAGS_DEBUG = -Wall -Werror -O0 -g
 
+# OS-SPECIFIC SETTINGS
+ifeq ($(OS),Windows_NT)
+  # Link libgcc and libstdc++ statically on Windows
+  LDFLAGS += -static-libgcc -static-libstdc++
+  LIBS += -LC:/msys64/mingw64/bin -L:/msys64/mingw64/lib
+  LINK += -l:glfw3.dll -l:libcglm.a
+  INCLUDE += -I../include
+else
+  detected_OS := $(shell uname)
+  ifeq ($(detected_OS),Linux)
+    # LINUX-DEPENDENT SETTINGS
+    LIBS += -L /usr/lib/x86_64-linux-gnu/
+    INCLUDE += -I ../include
+    LINK += -l:libcglm.so.0 -l:libglfw.so.3 -lGL -lX11 -lpthread -l:libXrandr.so.2 -l:libXi.so.6 -ldl -lm
+  endif
+endif
+
+
+.PHONY: win
 win:
-	gcc -Wall -Werror -I../include -LC:/msys64/mingw64/bin -L:/msys64/mingw64/lib -o Jack $(FILES) -l:glfw3.dll -l:libcglm.a
+	gcc $(FLAGS) $(INCLUDE) $(LIBS) -o Jack $(FILES) $(LINK)
 
+.PHONY: linux
 linux:
-	gcc -Wall -Werror -I../include -L/usr/lib/x86_64-linux-gnu -o Jack $(FILES) -l:libcglm.so.0 -l:libglfw.so.3 -lGL -lX11 -lpthread -l:libXrandr.so.2 -l:libXi.so.6 -ldl -lm
+	gcc $(FLAGS) $(INCLUDE) $(LIBS) -o Jack $(FILES) $(LINK)
 
+.PHONY: debug_linux
 debug_linux:
-	gcc -g -O0 -Wall -Werror -I../include -L/usr/lib/x86_64-linux-gnu -o Jack $(FILES) -l:libcglm.so.0 -l:libglfw.so.3 -lGL -lX11 -lpthread -l:libXrandr.so.2 -l:libXi.so.6 -ldl -lm
+	gcc $(FLAGS_DEBUG) $(INCLUDE) $(LIBS) -o Jack $(FILES) $(LINK)
 
+.PHONY: debug_win
 debug_win:
-	gcc -g -Wall -Werror -I../include -LC:/msys64/mingw64/bin -L:/msys64/mingw64/lib -o Jack $(FILES) -l:glfw3.dll -l:libcglm.a
+	gcc $(FLAGS_DEBUG) $(INCLUDE) $(LIBS) -o Jack $(FILES) $(LINK)
 
+.PHONY: object_files
+object_files:
+	gcc -c $(FLAGS_DEBUG) $(INCLUDE) $(LIBS) -fpic $(OBJ_FILES) $(LINK)


### PR DESCRIPTION
Added .o build recipe for 3DChess's object file dependencies files, plus made things a little easier to read with some logic for cross-platform building.