### PR TITLE
Bug fixes, spring based ragdoll, additional bone stats

### DIFF
--- a/include/entity_str.h
+++ b/include/entity_str.h
@@ -65,7 +65,12 @@ typedef struct animation {
 } ANIMATION;
 
 typedef struct bone {
+  // Position of bone base (point at which parent connects to the bone)
+  // in entity space
   vec3 coords;
+  // Position of bone tail (point at which children extend from the bone)
+  // in entity space
+  vec3 tail;
   int parent;
   int num_children;
 } BONE;
@@ -82,6 +87,9 @@ typedef struct model {
      a resource for easy keyframe interpolation */
   int *sled_block;
   BONE *bones;
+  /* Each element's index corresponds to the bone of the same index. Element
+     value consists of an array containing indicies of children */
+  int **bone_relations;
   COLLIDER *colliders;
   /* Each element's index corresponds to the collider of the same index.
      Element value corresponds to bone represneted by collider */
@@ -128,7 +136,6 @@ typedef struct entity {
   vec3 velocity;
   vec3 ang_velocity;
   float inv_mass;
-  //float mass;
   /* Physics system status
      Bit layout: 0...0[MUTABLE/IMMUTABLE][DRIVEN/DRIVING][STATIC/DYNAMIC] */
   int type;

--- a/include/obj_preprocessor.h
+++ b/include/obj_preprocessor.h
@@ -28,6 +28,7 @@ typedef struct face_vert {
 } FACE_VERT;
 
 BONE *bones;
+int **bone_relations;
 size_t b_buff_len;
 size_t b_len;
 

--- a/include/physics.h
+++ b/include/physics.h
@@ -75,8 +75,14 @@ void free_faces(F_HEAP *heap);
 
 void solve_collision(COL_ARGS *a_args, COL_ARGS *b_args, vec3 p_dir,
                      vec3 p_loc);
+// int spring_response(ENTITY *entity, int bone, int b_col, float delta_time);
+// void spring_calc(ENTITY *entity, int p_bone, COLLIDER *p_col, int c_bone,
+//                  COLLIDER *c_col, float delta_time);
 void calc_inertia_tensor(ENTITY *ent, size_t col_offset, COLLIDER *collider,
                          float inv_mass, mat4 dest);
+// void global_inv_inertia(mat4 inv_inertia, mat4 rotation, mat4 dest);
 
 int double_buffer(void **buffer, size_t *buff_size, size_t unit_size);
 void vec3_remove_noise(vec3 vec, float threshold);
+// void get_model_mat(ENTITY *entity, mat4 model);
+// void global_collider(mat4 model_mat, COLLIDER *source, COLLIDER *dest);

--- a/include/simulation.h
+++ b/include/simulation.h
@@ -111,6 +111,7 @@ int epa_response(COLLIDER *a, COLLIDER *b, vec3 *simplex, vec3 p_dir,
 void collision_point(COLLIDER *a, COLLIDER *b, vec3 p_vec, vec3 dest);
 void solve_collision(COL_ARGS *a_args, COL_ARGS *b_args, vec3 p_dir,
                      vec3 p_loc);
+// int spring_response(ENTITY *entity, int bone, int b_col, float delta_time);
 void calc_inertia_tensor(ENTITY *ent, size_t col_offset, COLLIDER *collider,
                          float inv_mass, mat4 dest);
 int double_buffer(void **buffer, size_t *buff_size, size_t unit_size);

--- a/src/main.c
+++ b/src/main.c
@@ -169,9 +169,9 @@ int main() {
 
   //ragdoll->type |= T_DRIVING;
   ragdoll->inv_mass = 1.0;
-  ragdoll->scale[0] = 2.0;
-  ragdoll->scale[1] = 2.0;
-  ragdoll->scale[2] = 2.0;
+  ragdoll->scale[0] = 1.0;
+  ragdoll->scale[1] = 1.0;
+  ragdoll->scale[2] = 1.0;
   for (size_t i = 0; i < ragdoll->model->num_bones; i++) {
     ragdoll->np_data[i].inv_mass = 1.0;
   }
@@ -272,7 +272,7 @@ int main() {
 
     /* Animation */
 
-    animate(player, 1, cur_frame);
+    animate(player, 0, cur_frame);
 
     /* Physics */
 
@@ -301,7 +301,7 @@ int main() {
                          -camera_model_pos[2] };
 
     glm_mat4_identity(view);
-    camera_offset[1] = -dude->bones[18].coords[1];
+    camera_offset[1] = -dude->bones[1].coords[1];
     glm_translate(view, camera_offset);
     glm_rotate_x(view, glm_rad(pitch), view);
     glm_rotate_y(view, glm_rad(yaw), view);

--- a/src/model.c
+++ b/src/model.c
@@ -77,5 +77,9 @@ void free_model(MODEL *model) {
   free(model->bones);
   free(model->colliders);
   free(model->collider_bone_links);
+  for (int i = 0; i < model->num_bones; i++) {
+    free(model->bone_relations[i]);
+  }
+  free(model->bone_relations);
   free(model);
 }

--- a/src/simulation.c
+++ b/src/simulation.c
@@ -149,9 +149,9 @@ int simulate_frame() {
           glm_vec3_copy(entity->np_data[bone].velocity, col_vel);
           glm_vec3_copy(entity->np_data[bone].ang_velocity, col_ang_vel);
           if (colliders[col].category == HURT_BOX &&
-              (col_vel[0] != 0.0 || col_vel[1] != 0.0 || col_vel[2] != 0.0 ||
+              ((col_vel[0] != 0.0 || col_vel[1] != 0.0 || col_vel[2] != 0.0 ||
                col_ang_vel[0] != 0.0 || col_ang_vel[1] != 0.0 ||
-               col_ang_vel[2] != 0.0)) {
+               col_ang_vel[2] != 0.0) || moving)) {
             moving = 1;
             status = oct_tree_delete(physics_tree,
                                      entity->tree_offsets[col][PHYS_TREE]);
@@ -207,6 +207,7 @@ int collision_test(ENTITY *subject, size_t offset) {
       glm_quat_normalize(subject->rotation);
     } else {
       subject->np_data[bone].velocity[1] -= (delta_time * GRAVITY);
+      // spring_response(subject, bone, offset, delta_time);
       glm_vec3_scale(subject->np_data[bone].velocity, delta_time, delta_d);
       glm_translate(subject->bone_mats[bone][LOCATION], delta_d);
 
@@ -295,6 +296,7 @@ int collision_test(ENTITY *subject, size_t offset) {
       collider.data.radius *= p_ent->scale[0];
     }
 
+    //if (p_ent != subject) {
     if ((subject->type & T_DRIVING && p_ent != subject) ||
         ((subject->type & T_DRIVING) == 0 &&
          (p_ent != subject || p_obj->collider_offset != offset))) {


### PR DESCRIPTION
## Functionality
- Implements a spring based ragdoll model
  - *NOTE* This is very unstable, basically unusable
  - Real ragdoll physics will be implemented utilizing Featherstone's algorithm
  - **This code will most likely not be merged. Here for reference purposes**
- Quality of life/bug fixes:
  - 8-vertex colliders will now be rendered as polyhedra with faces, rather than just an outline of dots
  - Fixed bugs in collider face detection, which were resulting in crashes
  - **This code will more than likely be merged**
- Misc:
  - Adds `tail` attribute to bones, which is the position at which it's children connect to it
  - Adds `bone_relations` to entity, which gives the list of children bone indices for each entity's bone
  - **These features may or may not be merged depending on their utility for the actual ragdoll implementation**